### PR TITLE
using key lookup instead, ignore argo key

### DIFF
--- a/src/assets/diff.sh
+++ b/src/assets/diff.sh
@@ -19,7 +19,8 @@ find "$@" -type f -exec yq e -i 'del(
   .webhooks,
   .data,
   .spec.caBundle,
-  .metadata.annotations == with_entries(select(.key == "kubectl.kubernetes.io/last-applied-configuration"))
+  .metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"],
+  .metadata.annotations["argocd.argoproj.io/tracking-id"]
   )' {} \;
 
 diff "${DIFF_ARGS[@]}" "$@" | awk '!/^diff/ {if ($1 ~ /(---|\+\+\+)/) {print $1, $2} else {print $0}}'    


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Using key as lookup makes it easier and less buggy

Fixes # (issue)
#7 
